### PR TITLE
Adds unsigned-deposit-root to deposit_data.json

### DIFF
--- a/src/utils/credentials.py
+++ b/src/utils/credentials.py
@@ -86,7 +86,8 @@ def export_deposit_data_json(*, credentials: List[ValidatorCredentials], folder:
         )
         signed_deposit_datum = sign_deposit_data(deposit_datum, credential.signing_sk)
         datum_dict = signed_deposit_datum.as_dict()
-        datum_dict.update({'deposit_data_root': signed_deposit_datum.hash_tree_root})
+        datum_dict.update({'deposit_data_root': deposit_datum.hash_tree_root})
+        datum_dict.update({'signed_deposit_data_root': signed_deposit_datum.hash_tree_root})
         deposit_data.append(datum_dict)
 
     filefolder = os.path.join(folder, 'deposit_data-%i.json' % time.time())

--- a/src/utils/eth2_deposit_check.py
+++ b/src/utils/eth2_deposit_check.py
@@ -30,7 +30,7 @@ def verify_deposit(deposit_data_dict: dict) -> bool:
     withdrawal_credentials = bytes.fromhex(deposit_data_dict['withdrawal_credentials'])
     amount = deposit_data_dict['amount']
     signature = bytes.fromhex(deposit_data_dict['signature'])
-    deposit_data_root = bytes.fromhex(deposit_data_dict['deposit_data_root'])
+    deposit_data_root = bytes.fromhex(deposit_data_dict['signed_deposit_data_root'])
 
     # Verify deposit amount
     if not MIN_DEPOSIT_AMOUNT < amount <= MAX_DEPOSIT_AMOUNT:


### PR DESCRIPTION
In order to verify the signature, the unsigned deposit data root is added to `deposit_data.json`.
