### PR TITLE
Example of how to setup validators using Docker for the Eth2 Launch Pad for Medalla testnet 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Prevent your local modules and debug logs from being
+# copied onto your Docker image and possibly overwriting
+# modules installed within your image
+.git
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv/
 *.egg-info
 *.egg
 __pycache__
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.8.5-slim-buster
+
+WORKDIR /app
+
+# Prevent Python from generating .pyc files
+ENV PYTHONGDONTWRITEBYTECODE 1
+# Turns off buffering for easier container logging
+ENV PYTHONUNBUFFERED 1
+
+# Install pip requirements
+COPY requirements.txt setup.py ./
+
+RUN python -m pip install -r requirements.txt && \
+  python setup.py install
+
+# RUN python -m pip install -r requirements.txt
+# Install Git and Vim
+RUN apt-get update && \
+  apt-get install -y gcc && \
+  apt-get install -y git vim
+
+# Generate deposit keys using Ethereum Foundation deposit tool
+RUN git clone https://github.com/ethereum/eth2.0-deposit-cli.git && \
+  cd eth2.0-deposit-cli && \
+  chmod a+x ./deposit.sh
+
+# Save validator mnemonic keystore files
+
+WORKDIR /launcher/eth2.0-deposit-cli
+
+CMD ["./deposit.sh install"]
+
+# Prevent Docker container from stopping after running it
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,6 @@ FROM python:3.8.5-slim-buster
 
 WORKDIR /app
 
-# Prevent Python from generating .pyc files
-ENV PYTHONGDONTWRITEBYTECODE 1
-# Turns off buffering for easier container logging
-ENV PYTHONUNBUFFERED 1
-
-# Install pip requirements
-COPY requirements.txt setup.py ./
-
-RUN python -m pip install -r requirements.txt && \
-  python setup.py install
-
-# RUN python -m pip install -r requirements.txt
 # Install Git and Vim
 RUN apt-get update && \
   apt-get install -y gcc && \
@@ -22,11 +10,11 @@ RUN apt-get update && \
 # Generate deposit keys using Ethereum Foundation deposit tool
 RUN git clone https://github.com/ethereum/eth2.0-deposit-cli.git && \
   cd eth2.0-deposit-cli && \
+  python -m pip install -r requirements.txt && \
+  python setup.py install && \
   chmod a+x ./deposit.sh
 
-# Save validator mnemonic keystore files
-
-WORKDIR /launcher/eth2.0-deposit-cli
+WORKDIR /app/eth2.0-deposit-cli
 
 CMD ["./deposit.sh install"]
 

--- a/README.md
+++ b/README.md
@@ -343,3 +343,33 @@ python3 -m pip install -r requirements_test.txt
 ```sh
 python3 -m pytest .
 ```
+----
+
+### For Docker users
+
+1. Install and run Docker
+
+2. Build Docker image and Docker container
+
+```bash
+docker build --tag eth2.0:medalla .
+docker run -d --name eth2.0-medalla eth2.0:medalla
+```
+
+3. Inspect Docker logs
+
+```bash
+docker logs eth2.0-medalla
+```
+
+4. Enter the Shell of the Docker container
+
+```bash
+docker exec -it eth2.0-medalla ./deposit.sh --num_validators 1 --chain medalla /bin/bash
+```
+
+#### Troubleshooting:
+
+* View the Docker images: `docker images`
+* View the Docker containers: `docker ps -a`
+* Stop and remove the Docker container: `docker stop eth2.0-medalla && docker rm eth2.0-medalla`

--- a/README.md
+++ b/README.md
@@ -378,6 +378,19 @@ docker cp eth2.0-medalla:/app/eth2.0-deposit-cli/validator_keys ./
 
 7. Upload the files during the Eth2 Launch Pad for Medalla testnet process here https://medalla.launchpad.ethereum.org
 
+8. Quickstart example using Prysm to running an Eth 2.0 Beacon chain node and Validator node
+
+* Create a symlink so its ready to import the validator keys without having to modify the Prysm scripts.
+
+```bash
+ln -s $(pwd)/validator_keys $HOME/eth2.0-deposit-cli/
+```
+
+* Run the Docker commands in the following Prysm steps:
+  * https://docs.prylabs.network/docs/install/install-with-docker#installing-the-beacon-chain-and-validator
+  * https://docs.prylabs.network/docs/testnet/medalla#step-4-import-your-validator-accounts-into-prysm
+  * https://docs.prylabs.network/docs/testnet/medalla#step-5-run-your-beacon-node-and-validator
+
 #### Troubleshooting:
 
 * View the Docker images: `docker images`

--- a/README.md
+++ b/README.md
@@ -356,20 +356,32 @@ docker build --tag eth2.0:medalla .
 docker run -d --name eth2.0-medalla eth2.0:medalla
 ```
 
-3. Inspect Docker logs
+5. Setup and save validator mnemonic keystore files
 
 ```bash
-docker logs eth2.0-medalla
+docker exec -it eth2.0-medalla ./deposit.sh --num_validators 1 --mnemonic_language=english --chain medalla
 ```
 
-4. Enter the Shell of the Docker container
+* Enter password to secure the validator keystore(s) and repeat for confirmation
+* Write down the keyphrase (mnenomic) that is shown since it is the only wait to retrieve the deposit
+* Enter your keyphrase (mnemonic)
+* Wait for it to create your keys, save the keystore, create your deposit.
+
+6. Copy your keys from the Docker container's folder (e.g. /app/eth2.0-deposit-cli/validator_keys) to your local machine
 
 ```bash
-docker exec -it eth2.0-medalla ./deposit.sh --num_validators 1 --chain medalla /bin/bash
+docker cp eth2.0-medalla:/app/eth2.0-deposit-cli/validator_keys ./
 ```
+
+* The deposit_data.json file contains your validators' public keys
+* The validator keystores should be available in the ./validator_keys/ directory in the current folder of your local machine
+
+7. Upload the files during the Eth2 Launch Pad for Medalla testnet process here https://medalla.launchpad.ethereum.org
 
 #### Troubleshooting:
 
 * View the Docker images: `docker images`
 * View the Docker containers: `docker ps -a`
 * Stop and remove the Docker container: `docker stop eth2.0-medalla && docker rm eth2.0-medalla`
+* Enter the Shell of the Docker container: `docker exec -it eth2.0-medalla /bin/bash`
+* Inspect Docker logs: `docker logs eth2.0-medalla`


### PR DESCRIPTION
Example of how to setup validators using Docker for the Eth2 Launch Pad for Medalla testnet https://medalla.launchpad.ethereum.org/

Just follow the steps suggested in the README.

If you're using Prysm, also run `ln -s $(pwd)/validator_keys $HOME/eth2.0-deposit-cli/` to create a symlink so its ready to import the validator keys without having to modify their scripts. Then run the Docker commands in the following steps:

https://docs.prylabs.network/docs/install/install-with-docker#installing-the-beacon-chain-and-validator
https://docs.prylabs.network/docs/testnet/medalla#step-4-import-your-validator-accounts-into-prysm
https://docs.prylabs.network/docs/testnet/medalla#step-5-run-your-beacon-node-and-validator

Note that one of the Docker commands in the Prsym docs requires this PR to be merged https://github.com/prysmaticlabs/documentation/pull/202

Troubleshooting:
* Run the beacon node and validator node with flag `--verbosity=trace`
* Log to a file to get help `command > /path/to/log.txt`