### PR TITLE
Actually shortens words for abbrviated mnemonic test vectors

### DIFF
--- a/tests/test_key_handling/test_key_derivation/test_mnemonic.py
+++ b/tests/test_key_handling/test_key_derivation/test_mnemonic.py
@@ -4,7 +4,6 @@ import json
 from typing import (
     Sequence,
 )
-from unicodedata import normalize
 
 from staking_deposit.utils.constants import (
     MNEMONIC_LANG_OPTIONS,
@@ -12,6 +11,7 @@ from staking_deposit.utils.constants import (
 from staking_deposit.key_handling.key_derivation.mnemonic import (
     _index_to_word,
     _get_word_list,
+    abbreviate_words,
     get_seed,
     get_mnemonic,
     reconstruct_mnemonic,
@@ -52,7 +52,8 @@ def test_reconstruct_mnemonic(test_mnemonic: str) -> None:
 
 def abbreviate_mnemonic(mnemonic: str) -> str:
     words = str.split(mnemonic)
-    words = [normalize('NFKC', word) for word in words]
+    words = abbreviate_words(words)
+    assert all([len(word) <= 4 for word in words])
     return str.join(' ', words)
 
 


### PR DESCRIPTION
In #242, I didn't correctly implement a test for shortened versions of mnemonics.

In particular, `abbreviate_mnemonic()` in `test_mnemonic.py` didn't actually return the 4-letter variants of words, it just normalized the mnemonic and returned it. This PR addresses that.