### PR TITLE
Support `--chain goerli`

### DIFF
--- a/staking_deposit/cli/generate_keys.py
+++ b/staking_deposit/cli/generate_keys.py
@@ -34,6 +34,7 @@ from staking_deposit.utils.intl import (
 from staking_deposit.settings import (
     ALL_CHAINS,
     MAINNET,
+    PRATER,
     get_chain_setting,
 )
 
@@ -87,7 +88,8 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
             param_decls='--chain',
             prompt=choice_prompt_func(
                 lambda: load_text(['chain', 'prompt'], func='generate_keys_arguments_decorator'),
-                list(ALL_CHAINS.keys())
+                # Since `prater` is alias of `goerli`, do not show `prater` in the prompt message.
+                list(key for key in ALL_CHAINS.keys() if key != PRATER)
             ),
         ),
         jit_option(

--- a/staking_deposit/settings.py
+++ b/staking_deposit/settings.py
@@ -20,10 +20,8 @@ KILN = 'kiln'
 MainnetSetting = BaseChainSetting(NETWORK_NAME=MAINNET, GENESIS_FORK_VERSION=bytes.fromhex('00000000'))
 # Ropsten setting
 RopstenSetting = BaseChainSetting(NETWORK_NAME=ROPSTEN, GENESIS_FORK_VERSION=bytes.fromhex('80000069'))
-# GOERLI (PRATER is alias)
-_GOERLI_GENESIS_FORK_VERSION = bytes.fromhex('00001020')
-GoerliSetting = BaseChainSetting(NETWORK_NAME=GOERLI, GENESIS_FORK_VERSION=_GOERLI_GENESIS_FORK_VERSION)
-PraterSetting = BaseChainSetting(NETWORK_NAME=PRATER, GENESIS_FORK_VERSION=_GOERLI_GENESIS_FORK_VERSION)
+# Goreli setting
+GoerliSetting = BaseChainSetting(NETWORK_NAME=GOERLI, GENESIS_FORK_VERSION=bytes.fromhex('00001020'))
 # Merge Testnet (spec v1.1.9)
 KilnSetting = BaseChainSetting(NETWORK_NAME=KILN, GENESIS_FORK_VERSION=bytes.fromhex('70000069'))
 
@@ -32,7 +30,7 @@ ALL_CHAINS: Dict[str, BaseChainSetting] = {
     MAINNET: MainnetSetting,
     ROPSTEN: RopstenSetting,
     GOERLI: GoerliSetting,
-    PRATER: PraterSetting,
+    PRATER: GoerliSetting,  # Prater is the old name of the Prater/Goerli testnet
     KILN: KilnSetting,
 }
 

--- a/staking_deposit/settings.py
+++ b/staking_deposit/settings.py
@@ -10,30 +10,30 @@ class BaseChainSetting(NamedTuple):
 
 
 MAINNET = 'mainnet'
-PRATER = 'prater'
-KINTSUGI = 'kintsugi'
-KILN = 'kiln'
 ROPSTEN = 'ropsten'
+GOERLI = 'goerli'
+PRATER = 'prater'
+KILN = 'kiln'
 
 
 # Mainnet setting
 MainnetSetting = BaseChainSetting(NETWORK_NAME=MAINNET, GENESIS_FORK_VERSION=bytes.fromhex('00000000'))
 # Ropsten setting
 RopstenSetting = BaseChainSetting(NETWORK_NAME=ROPSTEN, GENESIS_FORK_VERSION=bytes.fromhex('80000069'))
-# Testnet (spec v1.0.1)
-PraterSetting = BaseChainSetting(NETWORK_NAME=PRATER, GENESIS_FORK_VERSION=bytes.fromhex('00001020'))
-# Merge Testnet (spec v1.1.4)
-KintsugiSetting = BaseChainSetting(NETWORK_NAME=KINTSUGI, GENESIS_FORK_VERSION=bytes.fromhex('60000069'))
+# GOERLI (PRATER is alias)
+_GOERLI_GENESIS_FORK_VERSION = bytes.fromhex('00001020')
+GoerliSetting = BaseChainSetting(NETWORK_NAME=GOERLI, GENESIS_FORK_VERSION=_GOERLI_GENESIS_FORK_VERSION)
+PraterSetting = BaseChainSetting(NETWORK_NAME=PRATER, GENESIS_FORK_VERSION=_GOERLI_GENESIS_FORK_VERSION)
 # Merge Testnet (spec v1.1.9)
 KilnSetting = BaseChainSetting(NETWORK_NAME=KILN, GENESIS_FORK_VERSION=bytes.fromhex('70000069'))
 
 
 ALL_CHAINS: Dict[str, BaseChainSetting] = {
     MAINNET: MainnetSetting,
-    PRATER: PraterSetting,
-    KINTSUGI: KintsugiSetting,
-    KILN: KilnSetting,
     ROPSTEN: RopstenSetting,
+    GOERLI: GoerliSetting,
+    PRATER: PraterSetting,
+    KILN: KilnSetting,
 }
 
 


### PR DESCRIPTION
https://blog.ethereum.org/2022/07/27/goerli-prater-merge-announcement/

> For the last testnet proof-of-stake transition, Goerli will merge with Prater. The combined Goerli/Prater network will retain the Goerli name post-merge.

In this PR:
1. Add GoerliSetting (Fix #272)
2. Use Goerli as the "main name". Do not show Prater in the prompt message.
3. Remove Kintsugi

Discussion: I kept Prater for backward compatibility, but maybe we can just remove it now...? @CarlBeek what do you think?