### PR TITLE
Update CI Xcode to 13.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ jobs:
           path: /tmp/artifacts
   build-macos:
     macos:
-      xcode: 12.4.0
+      xcode: 13.4.1
     working_directory: ~/repo
     steps:
       - run: xcodebuild -version


### PR DESCRIPTION
As of Aug 2, CircleCI will no longer offer Xcode images for `12.4.0` [sauce](https://discuss.circleci.com/t/xcode-image-deprecation/44294). This PR bumps the Xcode image to the latest stable release.