### PR TITLE
Backport `master` into `dev` to resolve merge conflicts

### DIFF
--- a/staking_deposit/settings.py
+++ b/staking_deposit/settings.py
@@ -21,7 +21,7 @@ SEPOLIA = 'sepolia'
 MainnetSetting = BaseChainSetting(NETWORK_NAME=MAINNET, GENESIS_FORK_VERSION=bytes.fromhex('00000000'))
 # Ropsten setting
 RopstenSetting = BaseChainSetting(NETWORK_NAME=ROPSTEN, GENESIS_FORK_VERSION=bytes.fromhex('80000069'))
-# Goreli setting
+# Goerli setting
 GoerliSetting = BaseChainSetting(NETWORK_NAME=GOERLI, GENESIS_FORK_VERSION=bytes.fromhex('00001020'))
 # Merge Testnet (spec v1.1.9)
 KilnSetting = BaseChainSetting(NETWORK_NAME=KILN, GENESIS_FORK_VERSION=bytes.fromhex('70000069'))


### PR DESCRIPTION
Despite #282, there are still merge conflicts between `dev` and `master`, this PR backports `master` into `dev` to fix that.