### PR TITLE
[BLS] adds 'existing-seed' to generate keys from a hashed mnemonic seed

### DIFF
--- a/staking_deposit/cli/existing_seed.py
+++ b/staking_deposit/cli/existing_seed.py
@@ -1,0 +1,44 @@
+import click
+from typing import (
+    Any,
+)
+
+from staking_deposit.utils.click import (
+    captive_prompt_callback,
+    jit_option,
+)
+from staking_deposit.utils.intl import load_text
+from staking_deposit.utils.validation import validate_int_range
+from .generate_keys import (
+    generate_keys,
+    generate_keys_arguments_decorator,
+)
+
+
+def validate_mnemonic(ctx: click.Context, param: Any, mnemonic: str) -> str:
+    return mnemonic
+
+
+@click.command(
+    help=''
+)
+@jit_option(
+    callback=validate_mnemonic,
+    help='',
+    param_decls='--seed',
+    prompt='Enter seed',
+    type=str,
+)
+@jit_option(
+    default=0,
+    help='',
+    param_decls="--validator_start_index",
+    prompt='Validator start index'
+)
+
+@generate_keys_arguments_decorator
+@click.pass_context
+def existing_seed(ctx: click.Context, seed: str, **kwargs: Any) -> None:
+    ctx.obj = {} if ctx.obj is None else ctx.obj  # Create a new ctx.obj if it doesn't exist
+    ctx.obj.update({'seed': bytes.fromhex(seed)})
+    ctx.forward(generate_keys)

--- a/staking_deposit/cli/generate_keys.py
+++ b/staking_deposit/cli/generate_keys.py
@@ -122,25 +122,44 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
 def generate_keys(ctx: click.Context, validator_start_index: int,
                   num_validators: int, folder: str, chain: str, keystore_password: str,
                   eth1_withdrawal_address: HexAddress, **kwargs: Any) -> None:
-    mnemonic = ctx.obj['mnemonic']
-    mnemonic_password = ctx.obj['mnemonic_password']
-    amounts = [MAX_DEPOSIT_AMOUNT] * num_validators
-    folder = os.path.join(folder, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
-    chain_setting = get_chain_setting(chain)
-    if not os.path.exists(folder):
-        os.mkdir(folder)
-    click.clear()
-    click.echo(RHINO_0)
-    click.echo(load_text(['msg_key_creation']))
-    credentials = CredentialList.from_mnemonic(
-        mnemonic=mnemonic,
-        mnemonic_password=mnemonic_password,
-        num_keys=num_validators,
-        amounts=amounts,
-        chain_setting=chain_setting,
-        start_index=validator_start_index,
-        hex_eth1_withdrawal_address=eth1_withdrawal_address,
-    )
+    if ctx.obj.get('mnemonic'):
+        mnemonic = ctx.obj['mnemonic']
+        mnemonic_password = ctx.obj['mnemonic_password']
+        amounts = [MAX_DEPOSIT_AMOUNT] * num_validators
+        folder = os.path.join(folder, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
+        chain_setting = get_chain_setting(chain)
+        if not os.path.exists(folder):
+            os.mkdir(folder)
+        click.clear()
+        click.echo(RHINO_0)
+        click.echo(load_text(['msg_key_creation']))
+        credentials = CredentialList.from_mnemonic(
+            mnemonic=mnemonic,
+            mnemonic_password=mnemonic_password,
+            num_keys=num_validators,
+            amounts=amounts,
+            chain_setting=chain_setting,
+            start_index=validator_start_index,
+            hex_eth1_withdrawal_address=eth1_withdrawal_address,
+        )
+    else:
+        seed = ctx.obj['seed']
+        amounts = [MAX_DEPOSIT_AMOUNT] * num_validators
+        folder = os.path.join(folder, DEFAULT_VALIDATOR_KEYS_FOLDER_NAME)
+        chain_setting = get_chain_setting(chain)
+        if not os.path.exists(folder):
+            os.mkdir(folder)
+        click.clear()
+        click.echo(RHINO_0)
+        click.echo(load_text(['msg_key_creation']))
+        credentials = CredentialList.from_seed(
+            seed=seed,
+            num_keys=num_validators,
+            amounts=amounts,
+            chain_setting=chain_setting,
+            start_index=validator_start_index,
+            hex_eth1_withdrawal_address=eth1_withdrawal_address,
+        )
     keystore_filefolders = credentials.export_keystores(password=keystore_password, folder=folder)
     deposits_file = credentials.export_deposit_data_json(folder=folder)
     if not credentials.verify_keystores(keystore_filefolders=keystore_filefolders, password=keystore_password):

--- a/staking_deposit/credentials.py
+++ b/staking_deposit/credentials.py
@@ -10,7 +10,10 @@ from eth_utils import to_canonical_address
 from py_ecc.bls import G2ProofOfPossession as bls
 
 from staking_deposit.exceptions import ValidationError
-from staking_deposit.key_handling.key_derivation.path import mnemonic_and_path_to_key
+from staking_deposit.key_handling.key_derivation.path import (
+    mnemonic_and_path_to_key,
+    seed_and_path_to_key
+)
 from staking_deposit.key_handling.keystore import (
     Keystore,
     ScryptKeystore,
@@ -43,7 +46,7 @@ class Credential:
     A Credential object contains all of the information for a single validator and the corresponding functionality.
     Once created, it is the only object that should be required to perform any processing for a validator.
     """
-    def __init__(self, *, mnemonic: str, mnemonic_password: str,
+    def __init__(self, *, seed: Optional[bytes] = None, mnemonic: str, mnemonic_password: str,
                  index: int, amount: int, chain_setting: BaseChainSetting,
                  hex_eth1_withdrawal_address: Optional[HexAddress]):
         # Set path as EIP-2334 format
@@ -54,10 +57,12 @@ class Credential:
         withdrawal_key_path = f'm/{purpose}/{coin_type}/{account}/0'
         self.signing_key_path = f'{withdrawal_key_path}/0'
 
-        self.withdrawal_sk = mnemonic_and_path_to_key(
-            mnemonic=mnemonic, path=withdrawal_key_path, password=mnemonic_password)
-        self.signing_sk = mnemonic_and_path_to_key(
-            mnemonic=mnemonic, path=self.signing_key_path, password=mnemonic_password)
+        if seed is not None:
+            self.withdrawal_sk = seed_and_path_to_key(seed=seed, path=withdrawal_key_path)
+            self.signing_sk = seed_and_path_to_key(seed=seed, path=self.signing_key_path)
+        else:
+            self.withdrawal_sk = mnemonic_and_path_to_key(mnemonic=mnemonic, path=withdrawal_key_path, password=mnemonic_password)
+            self.signing_sk = mnemonic_and_path_to_key(mnemonic=mnemonic, path=self.signing_key_path, password=mnemonic_password)
         self.amount = amount
         self.chain_setting = chain_setting
         self.hex_eth1_withdrawal_address = hex_eth1_withdrawal_address
@@ -184,6 +189,27 @@ class CredentialList:
         with click.progressbar(key_indices, label=load_text(['msg_key_creation']),
                                show_percent=False, show_pos=True) as indices:
             return cls([Credential(mnemonic=mnemonic, mnemonic_password=mnemonic_password,
+                                   index=index, amount=amounts[index - start_index], chain_setting=chain_setting,
+                                   hex_eth1_withdrawal_address=hex_eth1_withdrawal_address)
+                        for index in indices])
+
+    @classmethod
+    def from_seed(cls,
+                  *,
+                  seed: bytes,
+                  num_keys: int,
+                  amounts: List[int],
+                  chain_setting: BaseChainSetting,
+                  start_index: int,
+                  hex_eth1_withdrawal_address: Optional[HexAddress]) -> 'CredentialList':
+        if len(amounts) != num_keys:
+            raise ValueError(
+                f"The number of keys ({num_keys}) doesn't equal to the corresponding deposit amounts ({len(amounts)})."
+            )
+        key_indices = range(start_index, start_index + num_keys)
+        with click.progressbar(key_indices, label=load_text(['msg_key_creation']),
+                               show_percent=False, show_pos=True) as indices:
+            return cls([Credential(seed=seed, mnemonic='', mnemonic_password='',
                                    index=index, amount=amounts[index - start_index], chain_setting=chain_setting,
                                    hex_eth1_withdrawal_address=hex_eth1_withdrawal_address)
                         for index in indices])

--- a/staking_deposit/deposit.py
+++ b/staking_deposit/deposit.py
@@ -2,6 +2,7 @@ import click
 import sys
 
 from staking_deposit.cli.existing_mnemonic import existing_mnemonic
+from staking_deposit.cli.existing_seed import existing_seed
 from staking_deposit.cli.new_mnemonic import new_mnemonic
 from staking_deposit.utils.click import (
     captive_prompt_callback,
@@ -52,6 +53,7 @@ def cli(ctx: click.Context, language: str, non_interactive: bool) -> None:
 
 
 cli.add_command(existing_mnemonic)
+cli.add_command(existing_seed)
 cli.add_command(new_mnemonic)
 
 

--- a/staking_deposit/intl/en/credentials.json
+++ b/staking_deposit/intl/en/credentials.json
@@ -2,6 +2,9 @@
     "from_mnemonic": {
         "msg_key_creation": "Creating your keys:\t\t"
     },
+    "from_seed": {
+        "msg_key_creation": "Creating your keys:\t\t"
+    },
     "export_keystores": {
         "msg_keystore_creation": "Creating your keystores:\t"
     },

--- a/staking_deposit/key_handling/key_derivation/path.py
+++ b/staking_deposit/key_handling/key_derivation/path.py
@@ -30,6 +30,9 @@ def mnemonic_and_path_to_key(*, mnemonic: str, path: str, password: str) -> int:
     compliant with BIP39 mnemonics that use passwords, but is not used by this CLI outside of tests.
     """
     seed = get_seed(mnemonic=mnemonic, password=password)
+    return seed_and_path_to_key(seed, path)
+
+def seed_and_path_to_key(seed: bytes, path: str) -> int:
     sk = derive_master_SK(seed)
     for node in path_to_nodes(path):
         sk = derive_child_SK(parent_SK=sk, index=node)


### PR DESCRIPTION
I've modified the CLI such that users can generate/recover keys from a hashed mnemonic seed. This is useful if the mnemonic phrase is not backed up in its original form.

For example: users of [GridPlus' Lattice1](https://gridplus.io/products/grid-lattice1) hardware wallet have the ability to backup their wallets using a PIN-protected [SafeCard](https://gridplus.io/products/safe-cards). Their open-source [safecare-cli](https://github.com/GridPlus/safecard-cli) will recover the hashed seed of the mnemonic, so stakers using this backup method will benefit from having the option to use an `existing-seed`.