### PR TITLE
Fix RTL and LTR encoding with Arabic

### DIFF
--- a/staking_deposit/utils/click.py
+++ b/staking_deposit/utils/click.py
@@ -113,4 +113,15 @@ def choice_prompt_func(prompt_func: Callable[[], str], choices: Sequence[str]) -
     '''
     Formats the prompt and choices in a printable manner.
     '''
-    return lambda: '%s %s: ' % (prompt_func(), choices)
+    # A join with unconditional embedded LTR can add non-printing characters on some Terminals
+    # Iterate over choices instead and use LTR embedding if the string has RTL embedding
+    output = '['
+    for i in range(len(choices)):
+        output = output + choices[i]
+        if i < len(choices) - 1:
+            if '\u202b' in choices[i]:
+                output = output + '\u202a, \u202c'
+            else:
+                output = output + ', '
+    output = output + ']'
+    return lambda: '%s %s: ' % (prompt_func(), output)

--- a/staking_deposit/utils/constants.py
+++ b/staking_deposit/utils/constants.py
@@ -31,14 +31,15 @@ def _add_index_to_options(d: Dict[str, List[str]]) -> Dict[str, List[str]]:
     eg. {'en': ['English', 'en']} -> {'en': ['1. English', '1', 'English', 'en']}
     Requires dicts to be ordered (Python > 3.6)
     '''
-    keys = list(d.keys())  # Force copy dictionary keys top prevent iteration over changing dict
+    keys = list(d.keys())  # Force copy dictionary keys to prevent iteration over changing dict
     for i, key in enumerate(keys):
         d.update({key: ['%s. %s' % (i + 1, d[key][0]), str(i + 1)] + d[key]})
     return d
 
 
 INTL_LANG_OPTIONS = _add_index_to_options({
-    'ar': ['العربية', 'ar', 'Arabic'],
+    # Arabic is RTL: Start with right-to-left embedding and end with pop directional formatting.
+    'ar': ['\u202bالعربية\u202c', 'ar', 'Arabic'],
     'el': ['ελληνικά', 'el', 'Greek'],
     'en': ['English', 'en'],
     'fr': ['Français', 'Francais', 'fr', 'French'],


### PR DESCRIPTION
This solves #275, where the first two choices in the language selection are not displayed correctly:
```
Please choose your language ['1. العربية', '2. ελληνικά', '3. English', '4. Français', '5. Bahasa melayu', '6. Italiano', '7. 日本語', '8. 한국어', '9. Português do Brasil', '10. român', '11. 简体中文']:  [English]: 
```

As per https://stackoverflow.com/questions/65318857/how-to-embed-english-in-right-to-left-languages I am using right-to-left embedding for Arabic, and left-to-right embedding with the separating commas.

I first tried this with `return lambda: '%s %s: ' % (prompt_func(), '['+'\u202a, \u202c'.join(choices)+']')` but this creates non-printing characters when the text is already LTR. Instead, I am now using a more elaborate `for` loop.

Output with this change is correct in my terminal, though I have a hard time copy/pasting that into github 😅 

Trying it as an embedded image

![image](https://user-images.githubusercontent.com/71337066/216716529-f42d9e96-39ae-4f34-80e2-e6e50d7682df.png)

