### PR TITLE
fix error message grammar

### DIFF
--- a/staking_deposit/intl/en/utils/validation.json
+++ b/staking_deposit/intl/en/utils/validation.json
@@ -21,7 +21,7 @@
         "err_not_bls_form": "The given withdrawal credentials is not in BLS_WITHDRAWAL_PREFIX form."
     },
     "validate_bls_withdrawal_credentials_matching": {
-        "err_not_matching": "The given withdrawal credentials is matching the old BLS withdrawal credentials that mnemonic generated."
+        "err_not_matching": "The given withdrawal credentials does not match the old BLS withdrawal credentials that mnemonic generated."
     },
     "verify_bls_to_execution_change_json": {
         "msg_bls_to_execution_change_verification": "Verifying your BLSToExecutionChange file:\t"


### PR DESCRIPTION
The current error message says the opposite of what it intends to:
  The given withdrawal credentials **is matching** the old BLS withdrawal credentials that mnemonic generated.

Fixed.