### PR TITLE
Fix CircleCI tox env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,18 +5,18 @@ tox_common: &tox_common
   steps:
     - checkout
     - restore_cache:
-        key: tox-deps3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_test.txt" }}-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+        key: tox-deps4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_test.txt" }}-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
     - run:
         name: install dependencies
-        command: pip install --user tox
+        command: pip install tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox
+        command: tox
     - save_cache:
         paths:
           - .tox
           - ./eggs
-        key: tox-deps3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_test.txt" }}-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+        key: tox-deps4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements_test.txt" }}-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
 
 orbs:
   win: circleci/windows@2.2.0 # The Windows orb give you everything you need to start using the Windows executor.          


### PR DESCRIPTION
Thank @CarlBeek for finding and digging into this issue first.

### Issue
I believe somehow, the CircleCI `cimg/python:3.8` image was updated and led us having this problem: https://techoverflow.net/2022/02/03/how-to-fix-tox-attributeerror-module-virtualenv-create-via_global_ref-builtin-cpython-mac_os-has-no-attribute-cpython2macosarmframework/

### How did I fix it

- Remove `--user` command: Install and use tox in the default Python env (`/home/circleci/.pyenv/shims/python`) rather than `/home/circleci/.pyenv/versions/3.8.16/lib/python3.8/site-packages`.
- Run the default `tox` (`/home/circleci/.pyenv/shims/tox`)
