### PR TITLE
Update existing_mnemonic.json

### DIFF
--- a/staking_deposit/intl/en/cli/existing_mnemonic.json
+++ b/staking_deposit/intl/en/cli/existing_mnemonic.json
@@ -19,7 +19,7 @@
         "arg_validator_start_index": {
             "help": "Enter the index (key number) you wish to start generating more keys from. For example, if you've generated 4 keys in the past, you'd enter 4 here.",
             "prompt": "Enter the index (key number) you wish to start generating more keys from. For example, if you've generated 4 keys in the past, you'd enter 4 here.",
-            "confirm": "Please repeat the index to confirm"
+            "confirm": "Please repeat the index (key number) to confirm"
         }
     }
 }


### PR DESCRIPTION
When passing `--validator_start_index` in the command, the cli prompts directly for confirmation of index.

Since there are other confirmation prompts like address and language (which also includes index) it is not clear which index it is referring to.

Adding `(key number)` to the prompt to clarify the confirmation is for the key number.