### PR TITLE
Change to the new Holesky fork version

### DIFF
--- a/staking_deposit/settings.py
+++ b/staking_deposit/settings.py
@@ -35,7 +35,7 @@ ZhejiangSetting = BaseChainSetting(
     GENESIS_VALIDATORS_ROOT=bytes.fromhex('53a92d8f2bb1d85f62d16a156e6ebcd1bcaba652d0900b2c2f387826f3481f6f'))
 # Holesky setting
 HoleskySetting = BaseChainSetting(
-    NETWORK_NAME=HOLESKY, GENESIS_FORK_VERSION=bytes.fromhex('00017000'),
+    NETWORK_NAME=HOLESKY, GENESIS_FORK_VERSION=bytes.fromhex('01017000'),
     GENESIS_VALIDATORS_ROOT=bytes.fromhex('9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1'))
 
 


### PR DESCRIPTION
Due to the previous accident, Holesky will re-launch with a new fork version.

Ref: https://github.com/eth-clients/holesky/pull/73