### PR TITLE
Fix typo

### DIFF
--- a/staking_deposit/intl/en/utils/validation.json
+++ b/staking_deposit/intl/en/utils/validation.json
@@ -17,7 +17,7 @@
         "msg_ECDSA_hex_addr_withdrawal": "**[Warning] you are setting an Eth1 address as your withdrawal address. Please ensure that you have control over this address.**"
     },
     "validate_bls_withdrawal_credentials": {
-        "err_is_already_eth1_form": "The given withdrawal credentials is already in ETH1_ADDRESS_WITHDRAWAL_PREFIX form. Have you already set the EL (eth1) withdrawal addresss?",
+        "err_is_already_eth1_form": "The given withdrawal credentials is already in ETH1_ADDRESS_WITHDRAWAL_PREFIX form. Have you already set the EL (eth1) withdrawal address?",
         "err_not_bls_form": "The given withdrawal credentials is not in BLS_WITHDRAWAL_PREFIX form."
     },
     "validate_bls_withdrawal_credentials_matching": {


### PR DESCRIPTION
fix a typo `addresss` to `address` in file "staking_deposit/intl/en/utils/validation.json"