### PR TITLE
fix: min deposit amount should be valid

### DIFF
--- a/staking_deposit/utils/validation.py
+++ b/staking_deposit/utils/validation.py
@@ -85,7 +85,7 @@ def validate_deposit(deposit_data_dict: Dict[str, Any], credential: Credential) 
         return False
 
     # Verify deposit amount
-    if not MIN_DEPOSIT_AMOUNT < amount <= MAX_DEPOSIT_AMOUNT:
+    if not MIN_DEPOSIT_AMOUNT <= amount <= MAX_DEPOSIT_AMOUNT:
         return False
 
     # Verify deposit signature && pubkey


### PR DESCRIPTION
I found an validation error for deposit data, that it fails to verify if the amount is equal to `MIN_DEPOSIT_AMOUNT`. This doesn't matter now, but if a user puts the deposit amount in post-Electra(EIP-7251), this could lead to failure of validation.