### PR TITLE
Add Hoodi testnet support

### DIFF
--- a/staking_deposit/settings.py
+++ b/staking_deposit/settings.py
@@ -14,6 +14,7 @@ MAINNET = 'mainnet'
 SEPOLIA = 'sepolia'
 HOLESKY = 'holesky'
 MEKONG = 'mekong'
+HOODI = 'hoodi'
 
 # Mainnet setting
 MainnetSetting = BaseChainSetting(
@@ -31,6 +32,10 @@ HoleskySetting = BaseChainSetting(
 MekongSetting = BaseChainSetting(
     NETWORK_NAME=MEKONG, GENESIS_FORK_VERSION=bytes.fromhex('10637624'),
     GENESIS_VALIDATORS_ROOT=bytes.fromhex('9838240bca889c52818d7502179b393a828f61f15119d9027827c36caeb67db7'))
+# Hoodi setting
+HoodiSetting = BaseChainSetting(
+    NETWORK_NAME=HOODI, GENESIS_FORK_VERSION=bytes.fromhex('10000910'),
+    GENESIS_VALIDATORS_ROOT=bytes.fromhex('212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f'))
 
 
 ALL_CHAINS: Dict[str, BaseChainSetting] = {
@@ -38,6 +43,7 @@ ALL_CHAINS: Dict[str, BaseChainSetting] = {
     SEPOLIA: SepoliaSetting,
     HOLESKY: HoleskySetting,
     MEKONG: MekongSetting,
+    HOODI: HoodiSetting,
 }
 
 


### PR DESCRIPTION
The PR adds supporting for [Hoodi](https://github.com/eth-clients/hoodi) testnet

Genesis fork version can be verified here:
https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml#L11

Genesis validator root can be verified here:
https://github.com/eth-clients/hoodi/blob/main/metadata/genesis_validators_root.txt