### PR TITLE
Deprecate repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
+# ⚠️ DEPRECATED: This repository has been deprecated and is no longer maintained.
+# Please use the actively maintained fork at https://github.com/ethstaker/ethstaker-deposit-cli
+
 VENV_NAME?=venv
 VENV_ACTIVATE=. $(VENV_NAME)/bin/activate
 PYTHON=${VENV_NAME}/bin/python3.12
 DOCKER_IMAGE="ethereum/staking-deposit-cli:latest"
 
 help:
+	@echo ""
+	@echo "================================================================================"
+	@echo "⚠️  This repository has been DEPRECATED"
+	@echo "    Please use: https://github.com/ethstaker/ethstaker-deposit-cli"
+	@echo "================================================================================"
+	@echo ""
 	@echo "clean - remove build and Python file artifacts"
 	# Run with venv
 	@echo "venv_deposit - run deposit cli with venv"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # staking-deposit-cli
 
+> **⚠️ DEPRECATED: This repository has been deprecated and is no longer maintained.**
+>
+> **Please use the actively maintained fork at [ethstaker/ethstaker-deposit-cli](https://github.com/ethstaker/ethstaker-deposit-cli)**
+
 [![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/ethereum/staking-deposit-cli/badge)](https://www.gitpoap.io/gh/ethereum/staking-deposit-cli)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,26 @@
 from setuptools import find_packages, setup
+import warnings
 
 """
+⚠️ DEPRECATED: This repository has been deprecated and is no longer maintained.
+Please use the actively maintained fork at https://github.com/ethstaker/ethstaker-deposit-cli
+
 THIS IS A STUB FOR RUNNING THE APP
 """
+
+# Display deprecation warning when setup.py is run
+warnings.warn(
+    "\n" + "=" * 80 + "\n"
+    "⚠️  DEPRECATION WARNING\n"
+    "=" * 80 + "\n"
+    "This repository (ethereum/staking-deposit-cli) has been DEPRECATED.\n"
+    "It is no longer maintained and may contain security vulnerabilities.\n\n"
+    "Please use the actively maintained fork instead:\n"
+    "    https://github.com/ethstaker/ethstaker-deposit-cli\n"
+    "=" * 80 + "\n",
+    DeprecationWarning,
+    stacklevel=2
+)
 
 setup(
     name="staking_deposit",

--- a/staking_deposit/deposit.py
+++ b/staking_deposit/deposit.py
@@ -59,5 +59,17 @@ cli.add_command(generate_bls_to_execution_change)
 
 if __name__ == '__main__':
     check_python_version()
-    print('\n***Using the tool on an offline and secure device is highly recommended to keep your mnemonic safe.***\n')
+
+    # Display deprecation warning
+    print('\n' + '=' * 80)
+    print('⚠️  DEPRECATION WARNING')
+    print('=' * 80)
+    print('This repository (ethereum/staking-deposit-cli) has been DEPRECATED.')
+    print('It is no longer maintained and may contain security vulnerabilities.')
+    print('')
+    print('Please use the actively maintained fork instead:')
+    print('    https://github.com/ethstaker/ethstaker-deposit-cli')
+    print('=' * 80 + '\n')
+
+    print('***Using the tool on an offline and secure device is highly recommended to keep your mnemonic safe.***\n')
     cli()


### PR DESCRIPTION
As this repo is no longer actively maintained in lieu of the fork at https://github.com/ethstaker/ethstaker-deposit-cli.


This has already effectively happened, this repo just needs to be updated to reflect that: 
1. This repo doesn't even support the [Electra upgrade](https://eips.ethereum.org/EIPS/eip-7600) features
1. https://launchpad.ethereum.org/ only references the ethstaker version 